### PR TITLE
Address type erasure/reflection issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,19 +62,7 @@ dependencies {
 #### Example Usage
 
 ```java
-package com.handler.example;
-
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.newrelic.opentracing.LambdaTracer;
-import com.newrelic.opentracing.aws.LambdaTracing;
-import io.opentracing.util.GlobalTracer;
-
-import java.util.Map;
-
-public static class YourLambdaHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+public class YourLambdaHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     static {
         // Obtain an instance of the OpenTracing Tracer of your choice
         Tracer tracer = LambdaTracer.INSTANCE;

--- a/src/main/java/com/newrelic/opentracing/aws/LambdaTracing.java
+++ b/src/main/java/com/newrelic/opentracing/aws/LambdaTracing.java
@@ -52,14 +52,12 @@ public class LambdaTracing<Input, Output> {
 
     Span span = buildRootSpan(input, context, tracer, spanContext);
     try (Scope scope = tracer.activateSpan(span)) {
-      try {
-        Output output = realHandler.apply(input, context);
-        parseResponse(span, output);
-        return output;
-      } catch (Throwable throwable) {
-        span.log(SpanUtil.createErrorAttributes(throwable));
-        throw throwable;
-      }
+      Output output = realHandler.apply(input, context);
+      parseResponse(span, output);
+      return output;
+    } catch (Throwable throwable) {
+      span.log(SpanUtil.createErrorAttributes(throwable));
+      throw throwable;
     } finally {
       span.finish();
     }

--- a/src/main/java/com/newrelic/opentracing/aws/LambdaTracing.java
+++ b/src/main/java/com/newrelic/opentracing/aws/LambdaTracing.java
@@ -1,0 +1,80 @@
+package com.newrelic.opentracing.aws;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+
+/**
+ * Trace calls to lambda functions, for arbitrary Input and Output types.
+ *
+ * <p>For flexibility, applications may extend this class to enhance the root span or handle novel
+ * invocation event types.
+ *
+ * @param <Input> The invocation payload type for your lambda function.
+ * @param <Output> The result type for your lambda function.
+ */
+public class LambdaTracing<Input, Output> {
+  protected static final AtomicBoolean isColdStart = new AtomicBoolean(true);
+
+  /**
+   * One-line instrumentation convenience method.
+   *
+   * @param input The invocation event
+   * @param context The invocation context
+   * @param realHandler The callback that implements the business logic for this event handler
+   * @param <Input> The type of the invocation event
+   * @param <Output> The type of the response
+   * @return The invocation response (the return value of the realHandler callback)
+   */
+  public static <Input, Output> Output instrument(
+      Input input, Context context, BiFunction<Input, Context, Output> realHandler) {
+    return new LambdaTracing<Input, Output>().instrumentRequest(input, context, realHandler);
+  }
+
+  /**
+   * Instrument a Lambda invocation
+   *
+   * @param input The invocation event
+   * @param context The invocation context
+   * @param realHandler The function that implements the business logic. Will be invoked with the
+   *     input and context parameters, from within the instrumentation scope.
+   * @return the return value from realHandler
+   */
+  public Output instrumentRequest(
+      Input input, Context context, BiFunction<Input, Context, Output> realHandler) {
+    final Tracer tracer = GlobalTracer.get();
+    final SpanContext spanContext = extractContext(tracer, input);
+
+    Span span = buildRootSpan(input, context, tracer, spanContext);
+    try (Scope scope = tracer.activateSpan(span)) {
+      try {
+        Output output = realHandler.apply(input, context);
+        parseResponse(span, output);
+        return output;
+      } catch (Throwable throwable) {
+        span.log(SpanUtil.createErrorAttributes(throwable));
+        throw throwable;
+      }
+    } finally {
+      span.finish();
+    }
+  }
+
+  protected SpanContext extractContext(Tracer tracer, Object input) {
+    return HeadersParser.parseAndExtract(tracer, input);
+  }
+
+  protected Span buildRootSpan(
+      Input input, Context context, Tracer tracer, SpanContext spanContext) {
+    return SpanUtil.buildSpan(input, context, tracer, spanContext, isColdStart);
+  }
+
+  protected void parseResponse(Span span, Output output) {
+    ResponseParser.parseResponse(output, span);
+  }
+}

--- a/src/main/java/com/newrelic/opentracing/aws/StreamLambdaTracing.java
+++ b/src/main/java/com/newrelic/opentracing/aws/StreamLambdaTracing.java
@@ -48,12 +48,10 @@ public class StreamLambdaTracing {
 
     Span span = buildRootSpan(input, context, tracer, spanContext);
     try (Scope scope = tracer.activateSpan(span)) {
-      try {
-        realHandler.handleRequest(input, output, context);
-      } catch (Throwable throwable) {
-        span.log(SpanUtil.createErrorAttributes(throwable));
-        throw throwable;
-      }
+      realHandler.handleRequest(input, output, context);
+    } catch (Throwable throwable) {
+      span.log(SpanUtil.createErrorAttributes(throwable));
+      throw throwable;
     } finally {
       span.finish();
     }

--- a/src/main/java/com/newrelic/opentracing/aws/StreamLambdaTracing.java
+++ b/src/main/java/com/newrelic/opentracing/aws/StreamLambdaTracing.java
@@ -1,0 +1,70 @@
+package com.newrelic.opentracing.aws;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Trace calls to lambda functions, implementing manual JSON serialization.
+ *
+ * <p>For flexibility, applications may extend this class to enhance the root span.
+ */
+public class StreamLambdaTracing {
+  /**
+   * One-line instrumentation convenience method.
+   *
+   * @param input The invocation event's input stream
+   * @param output The invocation response output stream
+   * @param context The invocation context
+   * @param realHandler The callback that implements the business logic for this event handler
+   */
+  public static void instrument(
+      InputStream input, OutputStream output, Context context, RequestStreamHandler realHandler)
+      throws IOException {
+    new StreamLambdaTracing().instrumentRequest(input, output, context, realHandler);
+  }
+
+  /**
+   * Instrument a Lambda invocation
+   *
+   * @param input The invocation event's input stream
+   * @param output The invocation response output stream
+   * @param context The invocation context
+   * @param realHandler The function that implements the business logic. Will be invoked with the
+   *     input and context parameters, from within the instrumentation scope.
+   */
+  public void instrumentRequest(
+      InputStream input, OutputStream output, Context context, RequestStreamHandler realHandler)
+      throws IOException {
+    final Tracer tracer = GlobalTracer.get();
+    final SpanContext spanContext = extractContext(tracer, input);
+
+    Span span = buildRootSpan(input, context, tracer, spanContext);
+    try (Scope scope = tracer.activateSpan(span)) {
+      try {
+        realHandler.handleRequest(input, output, context);
+      } catch (Throwable throwable) {
+        span.log(SpanUtil.createErrorAttributes(throwable));
+        throw throwable;
+      }
+    } finally {
+      span.finish();
+    }
+  }
+
+  protected Span buildRootSpan(
+      InputStream input, Context context, Tracer tracer, SpanContext spanContext) {
+    return SpanUtil.buildSpan(input, context, tracer, spanContext, LambdaTracing.isColdStart);
+  }
+
+  protected SpanContext extractContext(Tracer tracer, InputStream input) {
+    return null;
+  }
+}

--- a/src/main/java/com/newrelic/opentracing/aws/TracingRequestStreamHandler.java
+++ b/src/main/java/com/newrelic/opentracing/aws/TracingRequestStreamHandler.java
@@ -6,26 +6,25 @@
 package com.newrelic.opentracing.aws;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import io.opentracing.Scope;
-import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Tracing request stream handler that creates a span on every invocation of a Lambda.
  *
  * <p>Implement this interface and update your AWS Lambda Handler name to reference your class name,
  * e.g., com.mycompany.HandlerClass
+ *
+ * <p>While RequestStreamHandler's handleRequest method may throw an IOException, doHandleRequest
+ * may not. For that reason, this interface is deprecated in favor of {@link StreamLambdaTracing}.
  */
+@Deprecated
 public interface TracingRequestStreamHandler
     extends com.amazonaws.services.lambda.runtime.RequestStreamHandler {
-
-  AtomicBoolean isColdStart = new AtomicBoolean(true);
 
   /**
    * Method that handles the Lambda function request.
@@ -39,19 +38,10 @@ public interface TracingRequestStreamHandler
   void doHandleRequest(InputStream input, OutputStream output, Context context);
 
   default void handleRequest(InputStream input, OutputStream output, Context context) {
-    final Tracer tracer = GlobalTracer.get();
-    final SpanContext spanContext = extractContext(tracer, input);
-
-    Span span = SpanUtil.buildSpan(input, context, tracer, spanContext, isColdStart);
-    try (Scope scope = tracer.activateSpan(span)) {
-      try {
-        doHandleRequest(input, output, context);
-      } catch (Throwable throwable) {
-        span.log(SpanUtil.createErrorAttributes(throwable));
-        throw throwable;
-      }
-    } finally {
-      span.finish();
+    try {
+      StreamLambdaTracing.instrument(input, output, context, this::doHandleRequest);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/com/newrelic/opentracing/aws/TracingRequestStreamHandler.java
+++ b/src/main/java/com/newrelic/opentracing/aws/TracingRequestStreamHandler.java
@@ -41,7 +41,7 @@ public interface TracingRequestStreamHandler
     try {
       StreamLambdaTracing.instrument(input, output, context, this::doHandleRequest);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException("Exception while processing Lambda invocation", e);
     }
   }
 

--- a/src/test/java/com/newrelic/opentracing/aws/ReflectionTest.java
+++ b/src/test/java/com/newrelic/opentracing/aws/ReflectionTest.java
@@ -1,44 +1,49 @@
 package com.newrelic.opentracing.aws;
 
+import static org.junit.Assert.assertEquals;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-
 public class ReflectionTest {
-    private static final int SYNTHETIC_MODIFIER = 0x1000;
+  private static final int SYNTHETIC_MODIFIER = 0x1000;
 
-    private Object handler;
+  private Object handler;
 
-    @Before
-    public void setup() {
-        handler = new TestHandler();
+  @Before
+  public void setup() {
+    handler = new TestHandler();
+  }
+
+  @Test
+  public void testInputReflection() {
+    // Ignoring synthetics, we expect handleRequest to take the declared type as its first arg.
+    // This is necessary for correct payload deserialization.
+    final Method handleRequest =
+        Arrays.stream(handler.getClass().getMethods())
+            .filter(
+                m ->
+                    ((m.getModifiers() & SYNTHETIC_MODIFIER) == 0)
+                        && m.getName().equals("handleRequest"))
+            .findFirst()
+            .orElseThrow(AssertionError::new);
+
+    assertEquals(APIGatewayProxyRequestEvent.class, handleRequest.getParameterTypes()[0]);
+  }
+
+  public static class TestHandler
+      implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+        APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent, Context context) {
+      return LambdaTracing.instrument(
+          apiGatewayProxyRequestEvent, context, (event, c) -> new APIGatewayProxyResponseEvent());
     }
-
-    @Test
-    public void testInputReflection() {
-        // Ignoring synthetics, we expect handleRequest to take the declared type as its first arg.
-        // This is necessary for correct payload deserialization.
-        final Method handleRequest = Arrays.stream(handler.getClass().getMethods())
-                .filter(m -> ((m.getModifiers() & SYNTHETIC_MODIFIER) == 0)
-                    && m.getName().equals("handleRequest"))
-                .findFirst()
-                .orElseThrow(AssertionError::new);
-
-        assertEquals(APIGatewayProxyRequestEvent.class, handleRequest.getParameterTypes()[0]);
-    }
-
-    public static class TestHandler implements TracingRequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-        @Override
-        public APIGatewayProxyResponseEvent doHandleRequest(APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent, Context context) {
-            return new APIGatewayProxyResponseEvent();
-        }
-    }
+  }
 }

--- a/src/test/java/com/newrelic/opentracing/aws/ReflectionTest.java
+++ b/src/test/java/com/newrelic/opentracing/aws/ReflectionTest.java
@@ -1,0 +1,44 @@
+package com.newrelic.opentracing.aws;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class ReflectionTest {
+    private static final int SYNTHETIC_MODIFIER = 0x1000;
+
+    private Object handler;
+
+    @Before
+    public void setup() {
+        handler = new TestHandler();
+    }
+
+    @Test
+    public void testInputReflection() {
+        // Ignoring synthetics, we expect handleRequest to take the declared type as its first arg.
+        // This is necessary for correct payload deserialization.
+        final Method handleRequest = Arrays.stream(handler.getClass().getMethods())
+                .filter(m -> ((m.getModifiers() & SYNTHETIC_MODIFIER) == 0)
+                    && m.getName().equals("handleRequest"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        assertEquals(APIGatewayProxyRequestEvent.class, handleRequest.getParameterTypes()[0]);
+    }
+
+    public static class TestHandler implements TracingRequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        @Override
+        public APIGatewayProxyResponseEvent doHandleRequest(APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent, Context context) {
+            return new APIGatewayProxyResponseEvent();
+        }
+    }
+}

--- a/src/test/java/com/newrelic/opentracing/aws/TracingRequestHandlerTest.java
+++ b/src/test/java/com/newrelic/opentracing/aws/TracingRequestHandlerTest.java
@@ -48,7 +48,7 @@ public class TracingRequestHandlerTest {
   public void before() {
     mockTracer.reset();
     // reset isColdStart before each test
-    TracingRequestHandler.isColdStart.set(true);
+    LambdaTracing.isColdStart.set(true);
   }
 
   @Test

--- a/src/test/java/com/newrelic/opentracing/aws/TracingRequestStreamHandlerTest.java
+++ b/src/test/java/com/newrelic/opentracing/aws/TracingRequestStreamHandlerTest.java
@@ -35,7 +35,7 @@ public class TracingRequestStreamHandlerTest {
   public void before() {
     mockTracer.reset();
     // reset isColdStart before each test
-    TracingRequestStreamHandler.isColdStart.set(true);
+    LambdaTracing.isColdStart.set(true);
   }
 
   @Test


### PR DESCRIPTION
This is a pretty broad rewrite, because the former approach cannot work.
TracingRequestHandler's type parameters erase to `Object` at runtime, which
defeats AWS's reflection-based automatic deserialization mechanism.

The new approach uses composition over inheritance: the user provides their
own event handler, using any mechanism AWS supports, and wraps their
business logic with our instrumentation. This allows reflection to work as
intended.

In addition, the TracingRequestStreamHandler class's doHandler method didn't
allow for IOException to be thrown, despite it being more or less inevitable.
`StreamLambdaTracing` addresses this issue, while mirroring the design of
`LambdaTracing`.