### PR TITLE
Update AWS s3 lib dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'
     // 2.2.7 is earliest version that has all needed event sources
     implementation 'com.amazonaws:aws-lambda-java-events:2.2.7'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.163'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.13'
     implementation 'com.amazonaws:aws-java-sdk-kinesis:1.11.163'
     implementation 'com.amazonaws:aws-java-sdk-dynamodb:1.11.163'
     implementation('io.opentracing:opentracing-api:0.33.0')


### PR DESCRIPTION
Update `com.amazonaws:aws-java-sdk-s3` to v1.12.13.  Addresses https://nvd.nist.gov/vuln/detail/CVE-2022-31159

https://issues.newrelic.com/browse/NR-112739
