### PR TITLE
Upgrade software.amazon.awssdk:s3 and software.amazon.awssdk:s3-event-notifications from version 2.40.11 to 2.44.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ repositories {
 
 dependencies {
     implementation platform("software.amazon.awssdk:bom:2.40.11")
-    implementation 'software.amazon.awssdk:s3'
-    implementation 'software.amazon.awssdk:s3-event-notifications'
+    implementation 'software.amazon.awssdk:s3:2.40.11'
+    implementation 'software.amazon.awssdk:s3-event-notifications:2.40.11'
 
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.3'
     implementation 'com.amazonaws:aws-lambda-java-events:3.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ repositories {
 
 dependencies {
     implementation platform("software.amazon.awssdk:bom:2.40.11")
-    implementation 'software.amazon.awssdk:s3:2.40.11'
-    implementation 'software.amazon.awssdk:s3-event-notifications:2.40.11'
+    implementation 'software.amazon.awssdk:s3:2.44.0'
+    implementation 'software.amazon.awssdk:s3-event-notifications:2.44.0'
 
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.3'
     implementation 'com.amazonaws:aws-lambda-java-events:3.15.0'


### PR DESCRIPTION
Upgrades `software.amazon.awssdk:s3` and `software.amazon.awssdk:s3-event-notifications` from `2.40.11` to `2.44.0`

Related issue: https://github.com/newrelic/newrelic-lambda-layers/issues/471