### PR TITLE
Upgrade AWS SDK to 2.44.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,10 @@ repositories {
 }
 
 dependencies {
-    implementation platform("software.amazon.awssdk:bom:2.40.11")
-    implementation 'software.amazon.awssdk:s3:2.44.0'
-    implementation 'software.amazon.awssdk:s3-event-notifications:2.44.0'
+//     Bump the BOM version only to avoid mixing AWS SDK versions
+    implementation platform("software.amazon.awssdk:bom:2.44.12")
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:s3-event-notifications'
 
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.3'
     implementation 'com.amazonaws:aws-lambda-java-events:3.15.0'


### PR DESCRIPTION
Upgrade AWS SDK from 2.44.0 to 2.44.12

Resolves Issue [#81](https://github.com/newrelic/java-aws-lambda/issues/81) of `newrelic/java-aws-lambda`

[Related Jira](https://new-relic.atlassian.net/browse/NR-568851)