### PR TITLE
Update aws sdk to 2.46.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
 //     Bump the BOM version only to avoid mixing AWS SDK versions
-    implementation platform("software.amazon.awssdk:bom:2.44.12")
+    implementation platform("software.amazon.awssdk:bom:2.46.5")
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:s3-event-notifications'
 


### PR DESCRIPTION
## Description

Resolve netty vulnerabilities by updating AWS SDK to 2.46.5

## GIthub Issue
https://github.com/newrelic/newrelic-java-agent/issues/2948